### PR TITLE
Devel

### DIFF
--- a/lib/AmpIO.h
+++ b/lib/AmpIO.h
@@ -132,15 +132,15 @@ public:
 
     /*! Indicates which encoder signal (0=Aup, 1=Adown, 2=Bup, 3=Bdown) was used for the estimated velocity.
         If the latched value was used, this corresponds to the encoder transition that triggered the latch. If the
-        free running counter was used, this indicates the next expected encoder signal (based on the current direction).
+        free running counter was used, this indicates the next expectd encoder signal (based on the current direction).
         This method is provided for testing and is not likely to be useful in applications. It is only valid
         for FPGA Firmware Version 6+. The method returns 0 for previous versions of firmware. */
     AmpIO_Int32 GetEncoderVelocityChannel(unsigned int index) const;
     AmpIO_Int32 GetEncoderNextChannel(unsigned int index) const;
 
-    bool GetEncoderDirChanged(unsigned int index) const;
+    bool GetEncoderVelocityOverflow(unsigned int index) const;
     bool GetEncoderDir(unsigned int index) const;
-    bool GetEncoderExpectedEdge(unsigned int index) const;
+    bool GetEncoderLatchOverflow(unsigned int index) const;
     AmpIO_Int32 GetEncoderAccPrev(unsigned int index) const;
     AmpIO_Int32 GetEncoderAccRec(unsigned int index) const;
     AmpIO_Int32 GetEncoderAccRunning(unsigned int index) const;

--- a/lib/AmpIO.h
+++ b/lib/AmpIO.h
@@ -122,24 +122,28 @@ public:
         it will return the estimated period corresponding to a true "islatch", and that period will
         occupy the lower 16-bits. */
     AmpIO_Int32 GetEncoderVelocity(unsigned int index) const;
+    AmpIO_Int32 GetEncoderPrevVelocity(unsigned int index) const;
 
     double GetEncoderAcceleration(unsigned int index) const;
     
     /*! Returns true if the estimated velocity is based on the most recent latched value.
         Returns false if it is based on a free-running counter. This method is provided for
         testing and is not likely to be useful in applications. It is only meaningful for FPGA Firmware
-        Version 6+. The method returns true for prior versions of firmware. */
-    bool GetIsVelocityLatched(unsigned int index) const;
 
     /*! Indicates which encoder signal (0=Aup, 1=Adown, 2=Bup, 3=Bdown) was used for the estimated velocity.
         If the latched value was used, this corresponds to the encoder transition that triggered the latch. If the
         free running counter was used, this indicates the next expected encoder signal (based on the current direction).
         This method is provided for testing and is not likely to be useful in applications. It is only valid
         for FPGA Firmware Version 6+. The method returns 0 for previous versions of firmware. */
-    int GetEncoderVelocityChannel(unsigned int index) const;
+    AmpIO_Int32 GetEncoderVelocityChannel(unsigned int index) const;
+    AmpIO_Int32 GetEncoderNextChannel(unsigned int index) const;
 
-    AmpIO_Int32 GetEncoderAccPrevRaw(unsigned int index) const;
-    AmpIO_Int32 GetEncoderAccRecRaw(unsigned int index) const;
+    bool GetEncoderDirChanged(unsigned int index) const;
+    bool GetEncoderDir(unsigned int index) const;
+    bool GetEncoderExpectedEdge(unsigned int index) const;
+    AmpIO_Int32 GetEncoderAccPrev(unsigned int index) const;
+    AmpIO_Int32 GetEncoderAccRec(unsigned int index) const;
+    AmpIO_Int32 GetEncoderAccRunning(unsigned int index) const;
 
     /*! Returns the raw encoder period (velocity) value.
         This method is provided for internal use and testing. */

--- a/lib/AmpIO.h
+++ b/lib/AmpIO.h
@@ -105,6 +105,19 @@ public:
 
     AmpIO_Int32 GetEncoderPosition(unsigned int index) const;
 
+
+    /*! Returns the encoder period, which is the time between two consecutive edges, as a signed value.
+        Specific details depend on the version of FPGA firmware. This value can be used to estimate the encoder
+        velocity This method probably should have been called GetEncoderPeriod.
+        \note In prior versions of this library (up through 1.3.0), there was an optional "islatch"
+        boolean parameter, which defaulted to true. This is no longer supported by FPGA Firmware
+        Version 6+ and thus has been removed. If this library is used with prior versions of firmware,
+        it will return the estimated period corresponding to a true "islatch", and that period will
+        occupy the lower 16-bits. */
+    AmpIO_UInt32 GetEncoderVelocity(unsigned int index) const;
+    AmpIO_Int32 GetEncoderPrevCounter(unsigned int index) const;
+
+    
     /*! Returns the encoder velocity, in counts per second, based on the FPGA measurement
         of the encoder period (i.e., time between two consecutive edges). Specifically, the
         velocity is given by 4/(period*clk) counts/sec, where clk is the period of the clock used to measure
@@ -112,18 +125,6 @@ public:
         If the counter overflows, the velocity is set to 0. This method should work with all versions of firmware,
         but has improved performance starting with Version 6. */
     double GetEncoderVelocityCountsPerSecond(unsigned int index) const;
-
-    /*! Returns the encoder period, which is the time between two consecutive edges, as a signed value.
-        Specific details depend on the version of FPGA firmware. This value can be used to estimate the encoder
-        velocity (see GetEncoderVelocityCountsPerSecond). This method probably should have been called GetEncoderPeriod.
-        \note In prior versions of this library (up through 1.3.0), there was an optional "islatch"
-        boolean parameter, which defaulted to true. This is no longer supported by FPGA Firmware
-        Version 6+ and thus has been removed. If this library is used with prior versions of firmware,
-        it will return the estimated period corresponding to a true "islatch", and that period will
-        occupy the lower 16-bits. */
-    AmpIO_Int32 GetEncoderVelocity(unsigned int index) const;
-    AmpIO_Int32 GetEncoderPrevVelocity(unsigned int index) const;
-
     double GetEncoderAcceleration(unsigned int index) const;
     
     /*! Returns true if the estimated velocity is based on the most recent latched value.

--- a/lib/AmpIO.h
+++ b/lib/AmpIO.h
@@ -123,6 +123,8 @@ public:
         occupy the lower 16-bits. */
     AmpIO_Int32 GetEncoderVelocity(unsigned int index) const;
 
+    double GetEncoderAcceleration(unsigned int index) const;
+    
     /*! Returns true if the estimated velocity is based on the most recent latched value.
         Returns false if it is based on a free-running counter. This method is provided for
         testing and is not likely to be useful in applications. It is only meaningful for FPGA Firmware
@@ -136,10 +138,15 @@ public:
         for FPGA Firmware Version 6+. The method returns 0 for previous versions of firmware. */
     int GetEncoderVelocityChannel(unsigned int index) const;
 
+    AmpIO_Int32 GetEncoderAccPrevRaw(unsigned int index) const;
+    AmpIO_Int32 GetEncoderAccRecRaw(unsigned int index) const;
+
     /*! Returns the raw encoder period (velocity) value.
         This method is provided for internal use and testing. */
     AmpIO_UInt32 GetEncoderVelocityRaw(unsigned int index) const;
 
+    AmpIO_UInt32 GetEncoderAccelerationRaw(unsigned int index) const;
+    
     /*! Returns midrange value of encoder position. */
     AmpIO_Int32 GetEncoderMidRange(void) const;
 

--- a/lib/AmpIO.h
+++ b/lib/AmpIO.h
@@ -115,6 +115,10 @@ public:
         it will return the estimated period corresponding to a true "islatch", and that period will
         occupy the lower 16-bits. */
     AmpIO_UInt32 GetEncoderVelocity(unsigned int index) const;
+
+
+    /*! Returns the encoder period (counter) of the previous full cycle.
+        Used internally to calculate acceleration. */ 
     AmpIO_Int32 GetEncoderPrevCounter(unsigned int index) const;
 
     
@@ -125,31 +129,32 @@ public:
         If the counter overflows, the velocity is set to 0. This method should work with all versions of firmware,
         but has improved performance starting with Version 6. */
     double GetEncoderVelocityCountsPerSecond(unsigned int index) const;
+
+    /*! Returns the encoder accleration in counts per second, based on the scaled difference
+        between the most recent full cycle and the previous full cycle. Since velocity is averaged
+        over an entire cycle, acceleration is applied to half the cycle to reduce delays. */
     double GetEncoderAcceleration(unsigned int index) const;
-    
-    /*! Returns true if the estimated velocity is based on the most recent latched value.
-        Returns false if it is based on a free-running counter. This method is provided for
-        testing and is not likely to be useful in applications. It is only meaningful for FPGA Firmware
 
-    /*! Indicates which encoder signal (0=Aup, 1=Adown, 2=Bup, 3=Bdown) was used for the estimated velocity.
-        If the latched value was used, this corresponds to the encoder transition that triggered the latch. If the
-        free running counter was used, this indicates the next expectd encoder signal (based on the current direction).
-        This method is provided for testing and is not likely to be useful in applications. It is only valid
-        for FPGA Firmware Version 6+. The method returns 0 for previous versions of firmware. */
-    AmpIO_Int32 GetEncoderVelocityChannel(unsigned int index) const;
-    AmpIO_Int32 GetEncoderNextChannel(unsigned int index) const;
-
+    /*! Returns whether the full cycle counter has overflows (22 bits) */
     bool GetEncoderVelocityOverflow(unsigned int index) const;
-    bool GetEncoderDir(unsigned int index) const;
-    bool GetEncoderLatchOverflow(unsigned int index) const;
-    AmpIO_Int32 GetEncoderAccPrev(unsigned int index) const;
-    AmpIO_Int32 GetEncoderAccRec(unsigned int index) const;
-    AmpIO_Int32 GetEncoderAccRunning(unsigned int index) const;
 
+    /*! Returns the direction the encoder is moving in. */
+    bool GetEncoderDir(unsigned int index) const;
+    
+    /*! Returns the latched period of five encoder quarter cycles
+        ago. Used internally to calculate acceleration. */
+    AmpIO_Int32 GetEncoderAccPrev(unsigned int index) const;
+
+    /*! Returns the latched period of the most recent encoder
+      quarter cycle. Used internally to calculate acceleration. */
+    AmpIO_Int32 GetEncoderAccRec(unsigned int index) const;
+    
     /*! Returns the raw encoder period (velocity) value.
         This method is provided for internal use and testing. */
     AmpIO_UInt32 GetEncoderVelocityRaw(unsigned int index) const;
 
+    /*! Returns the raw encoder acceleration fields value.
+        This method is provided for internal use and testing. */
     AmpIO_UInt32 GetEncoderAccelerationRaw(unsigned int index) const;
     
     /*! Returns midrange value of encoder position. */

--- a/lib/code/AmpIO.cpp
+++ b/lib/code/AmpIO.cpp
@@ -44,22 +44,16 @@ const AmpIO_UInt32 ANALOG_POS_MASK  = 0xffff0000;  /*!< Mask for analog pot ADC 
 const AmpIO_UInt32 ADC_MASK         = 0x0000ffff;  /*!< Mask for right aligned ADC bits */
 const AmpIO_UInt32 DAC_MASK         = 0x0000ffff;  /*!< Mask for 16-bit DAC values */
 const AmpIO_UInt32 ENC_POS_MASK     = 0x00ffffff;  /*!< Encoder position mask (24 bits) */
-const AmpIO_UInt32 ENC_OVER_MASK    = 0x01000000;  /*!< Encoder bit overflo mask */
+const AmpIO_UInt32 ENC_OVER_MASK    = 0x01000000;  /*!< Encoder bit overflow mask */
 const AmpIO_UInt32 ENC_VEL_MASK_16  = 0x0000ffff;  /*!< Mask for encoder velocity (period) bits, Firmware Version <=5 (16 bits) */
 const AmpIO_UInt32 ENC_VEL_MASK_22  = 0x003fffff;  /*!< Mask for encoder velocity (period) bits, Firmware Version >=6 (22 bits) */
 const AmpIO_UInt32 ENC_ACC_REC_MS_MASK     = 0xfff00000;
 const AmpIO_UInt32 ENC_ACC_REC_LS_MASK     = 0x3fc00000;
 const AmpIO_UInt32 ENC_ACC_PREV_MASK     = 0x000fffff;  
-const AmpIO_UInt32 ENC_VEL_STATUS   = 0xfe0000;
 
 // Following offsets are for FPGA Firmware Version 6+ (22 bits)
 const AmpIO_UInt32 ENC_VEL_OVER_MASK   = 0x80000000;  /*!< Mask for encoder velocity (period) direction changed bit */
 const AmpIO_UInt32 ENC_DIR_MASK     = 0x40000000;  /*!< Mask for encoder velocity (period) direction bit */
-const AmpIO_UInt32 ENC_CHN_MASK     = 0x00300000;  /*!< Mask for encoder velocity (period) channel bits */
-const AmpIO_UInt32 ENC_NEXT_CHN_MASK     = 0x00c00000;  /*!< Mask for expected encoder velocity (period) channel bits */
-const AmpIO_UInt32 ENC_LATCH_OVER_MASK = 0x01000000; /*!< Mask for whether a latch value is at overflow */
-const AmpIO_UInt32 LATCH_OVERFLOW   = 0xFFFFF;     /* Overflow value of a quarter latch */
-
 const AmpIO_UInt32 DAC_WR_A         = 0x00300000;  /*!< Command to write DAC channel A */
 
 const double FPGA_sysclk_MHz        = 49.152;      /* FPGA sysclk in MHz (from FireWire) */

--- a/lib/code/AmpIO.cpp
+++ b/lib/code/AmpIO.cpp
@@ -423,7 +423,14 @@ double AmpIO::GetEncoderAcceleration(unsigned int index) const
     double cur_perd = ((buff & ENC_ACC_REC_MASK) >> 16);
 
    if (GetFirmwareVersion() >= 6) {
-       return ((double) (cur_perd - prev_perd))/prev_perd;
+       double acc = ((double) (cur_perd - prev_perd))/prev_perd;
+       if (acc > 0.3){
+           return 0.3;
+       } else if (acc < -0.3) {
+           return -0.3;
+       } else {
+           return acc;
+       }
     }
 }
 

--- a/lib/code/AmpIO.cpp
+++ b/lib/code/AmpIO.cpp
@@ -417,16 +417,13 @@ double AmpIO::GetEncoderAcceleration(unsigned int index) const
     if (index >= NUM_CHANNELS)
         return 0L;
 
-    quadlet_t a_buff = GetEncoderAccelerationRaw(index);
-    quadlet_t v_buff = GetEncoderVelocityRaw(index);
+    quadlet_t buff = GetEncoderAccelerationRaw(index);
     
-    const double period = 1.0 / 3072000.0; // Clock period defined in firmware - different than system clock
-    double prev_perd = ((AmpIO_UInt32) (a_buff & ENC_ACC_PAST_MASK))*period;
-    double cur_perd = (((AmpIO_UInt32) (a_buff & ENC_ACC_REC_MASK)) >> 16)*period;
-    double total_perd = ((AmpIO_UInt32) (v_buff & ENC_VEL_MASK_22))*period;
-    
+    double prev_perd = (buff & ENC_ACC_PAST_MASK);
+    double cur_perd = ((buff & ENC_ACC_REC_MASK) >> 16);
+
    if (GetFirmwareVersion() >= 6) {
-       return (1.0/cur_perd - 1.0/prev_perd)/total_perd;
+       return ((double) (cur_perd - prev_perd))/prev_perd;
     }
 }
 


### PR DESCRIPTION
Updated code for velocity estimation. Kept GetEncoderVelocityCountsPerSecond as the"new velocity function that returns double and kept the one that returns counter for backwards compatibility. Copied over code to make GetEncoderVelocityCountsPerSecond backwards compatible with firmware 5. Not sure what the correct behaviour for the GetEncoderVelocity function is for firmware >= 6 - currently set to masking and getting the 22 bit counter. 